### PR TITLE
解决截图翻译时连字符和换行问题

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -416,7 +416,12 @@ bool MainWindow::recognizeImage()
         QString line = in.readLine();
         while (!line.isNull()) {
             INFO << "readline";
-            ocr_result.append(line);
+            if (ocr_result.endsWith("-")) {
+                ocr_result.chop(2);
+                ocr_result.append(line);
+            } else {
+                ocr_result.append(" "+line);
+            }
             line = in.readLine();
         }
         INFO << "The ocr_result is:" << ocr_result;


### PR DESCRIPTION

解决的问题:

1. 截图翻译连字符没有正确处理,
2. 换行之后前一行的单词和后一行的单词连在一起也没有用空格分开