### PR TITLE
添加判断连字符

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -416,7 +416,7 @@ bool MainWindow::recognizeImage()
         QString line = in.readLine();
         while (!line.isNull()) {
             INFO << "readline";
-            if (ocr_result.endsWith("-")) {
+            if (ocr_result.endsWith("-") || ocr_result.endsWith("‐")) {
                 ocr_result.chop(2);
                 ocr_result.append(line);
             } else {


### PR DESCRIPTION
添加判断连字符,

中划线和连字符肉眼看着是一样的, 在python在用ord测试码点不一样.

 `‐` 不是中划线,而是连字符 ord('‐')=8208
 `-` 中划线 ord('-')=45